### PR TITLE
Add flawed method

### DIFF
--- a/src/Demo.php
+++ b/src/Demo.php
@@ -6,4 +6,8 @@ namespace UlrichEckhardt\PhpstanSarifFormatterDemo;
 
 class Demo
 {
+    public function flawedMethod(): Demo
+    {
+        return null;
+    }
 }


### PR DESCRIPTION
Add some code with a flaw for demonstration purposes. The flaw is the obvious difference between the annotated return type and the actual one.